### PR TITLE
Meta vaults cannot re-add underlying vaults after removal

### DIFF
--- a/contracts/vault/allocate/SameAssetUnderlyingsAbstractVault.sol
+++ b/contracts/vault/allocate/SameAssetUnderlyingsAbstractVault.sol
@@ -281,6 +281,9 @@ abstract contract SameAssetUnderlyingsAbstractVault is AbstractVault {
         // Remove the underlying vault from the vault index map.
         vaultIndexMap = vaultIndexMapMem.removeValue(underlyingVaultIndex);
 
+        // reset allowance
+        _asset.safeApprove(underlyingVault, 0);
+
         // Call _afterRemoveVault
         _afterRemoveVault();
 

--- a/test/shared/SameAssetUnderlyingsAbstractVault.behaviour.ts
+++ b/test/shared/SameAssetUnderlyingsAbstractVault.behaviour.ts
@@ -590,6 +590,19 @@ export function shouldBehaveLikeSameAssetUnderlyingsAbstractVault(ctx: () => Sam
                     const removeVaultTx = await vault.connect(sa.governor.signer).removeVault(4)
                     await expect(removeVaultTx).to.emit(vault, "RemovedVault").withArgs(4, nVaultAddress)
                 })
+                it("should be able to remove and re-add vault", async () => {
+                    const { vault, sa } = ctx()
+
+                    expect( await vault.resolveVaultIndex(0)).to.equal(bVault0.address);
+                    // Remove underlying vault
+                    const removeTx = vault.connect(sa.governor.signer).removeVault(0)
+                    await expect(removeTx).to.emit(vault, "RemovedVault").withArgs(0, bVault0.address)
+
+                    // Add it again
+                    totalUnderlyingVaultsBefore = (await vault.totalUnderlyingVaults()).toNumber()
+                    const addTx = vault.connect(sa.governor.signer).addVault(bVault0.address)
+                    await expect(addTx).to.emit(vault, "AddedVault").withArgs(totalUnderlyingVaultsBefore, bVault0.address)
+                })
             })
         })
     })


### PR DESCRIPTION
**Describe the bug**
In `SameAssetUnderlyingsAbstractVault.sol` assets are approved to the max uint256 amount using `SafeERC20.safeApprove`. According to the documentation within SafeERC20.sol:
```solidity
safeApprove should only be called when setting an initial allowance,
or when resetting it to zero. To increase and decrease it, use
'safeIncreaseAllowance' and 'safeDecreaseAllowance'
```
If the vault manager removes an underlying vault and tries to re-add it, the transaction will revert.

**Fix**
When removing a vault, resetting the allowance to 0