### PR TITLE
RoundUp for `mint`, `previewMint`, `withdraw` and `previewWithdraw`

### DIFF
--- a/contracts/vault/AbstractVault.sol
+++ b/contracts/vault/AbstractVault.sol
@@ -259,6 +259,11 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
                             CONVERTIONS
     //////////////////////////////////////////////////////////////*/
 
+    /**
+     * @notice The amount of assets that the Vault would exchange for the amount of shares provided, in an ideal scenario where all the conditions are met.
+     * @param shares The amount of vault shares to be converted to the underlying assets.
+     * @return assets The amount of underlying assets converted from the vault shares.
+     */
     function convertToAssets(uint256 shares)
         external
         view
@@ -269,6 +274,9 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
         assets = _convertToAssets(shares, false);
     }
 
+    /// @param shares The amount of vault shares to be converted to the underlying assets.
+    /// @param isRoundUp bool to indicate round up the assets
+    /// @dev isRoundUp is used to round-up the assets amount for mint and previewMint
     function _convertToAssets(uint256 shares, bool isRoundUp) internal view virtual returns (uint256 assets) {
         uint256 totalShares = totalSupply();
 
@@ -285,6 +293,11 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
         }
     }
 
+    /**
+     * @notice The amount of shares that the Vault would exchange for the amount of assets provided, in an ideal scenario where all the conditions are met.
+     * @param assets The amount of underlying assets to be convert to vault shares.
+     * @return shares The amount of vault shares converted from the underlying assets.
+     */
     function convertToShares(uint256 assets)
         external
         view
@@ -295,6 +308,9 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
         shares = _convertToShares(assets, false);
     }
 
+    /// @param assets The amount of underlying assets to be convert to vault shares.
+    /// @param isRoundUp bool to indicate round up the shares
+    /// @dev isRoundUp is used to round-up the shares amount for withdraw and previewWithdraw
     function _convertToShares(uint256 assets, bool isRoundUp) internal view virtual returns (uint256 shares) {
         uint256 totalShares = totalSupply();
 

--- a/contracts/vault/AbstractVault.sol
+++ b/contracts/vault/AbstractVault.sol
@@ -67,7 +67,7 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
     }
 
     function _previewDeposit(uint256 assets) internal view virtual returns (uint256 shares) {
-        shares = _convertToShares(assets);
+        shares = _convertToShares(assets, false);
     }
 
     function maxDeposit(address caller) external view override returns (uint256 maxAssets) {
@@ -102,7 +102,7 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
     }
 
     function _previewMint(uint256 shares) internal view virtual returns (uint256 assets) {
-        assets = _convertToAssets(shares);
+        assets = _convertToAssets(shares, true);
     }
 
     function maxMint(address owner) external view override returns (uint256 maxShares) {
@@ -162,7 +162,7 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
     }
 
     function _previewWithdraw(uint256 assets) internal view virtual returns (uint256 shares) {
-        shares = _convertToShares(assets);
+        shares = _convertToShares(assets, true);
     }
 
     function maxWithdraw(address owner) external view override returns (uint256 maxAssets) {
@@ -199,7 +199,7 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
     }
 
     function _previewRedeem(uint256 shares) internal view virtual returns (uint256 assets) {
-        assets = _convertToAssets(shares);
+        assets = _convertToAssets(shares, false);
     }
 
     function maxRedeem(address owner) external view override returns (uint256 maxShares) {
@@ -266,16 +266,22 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
         override
         returns (uint256 assets)
     {
-        assets = _convertToAssets(shares);
+        assets = _convertToAssets(shares, false);
     }
 
-    function _convertToAssets(uint256 shares) internal view virtual returns (uint256 assets) {
+    function _convertToAssets(uint256 shares, bool isRoundUp) internal view virtual returns (uint256 assets) {
         uint256 totalShares = totalSupply();
 
         if (totalShares == 0) {
             assets = shares; // 1:1 value of shares and assets
         } else {
-            assets = (shares * totalAssets()) / totalShares;
+            uint256 totalAssetsMem = totalAssets();
+            assets = (shares * totalAssetsMem) / totalShares;
+
+            // Round Up if needed
+            if(isRoundUp && mulmod(shares, totalAssetsMem, totalShares) > 0) {
+                assets += 1;
+            }
         }
     }
 
@@ -286,16 +292,22 @@ abstract contract AbstractVault is IERC4626Vault, InitializableToken, VaultManag
         override
         returns (uint256 shares)
     {
-        shares = _convertToShares(assets);
+        shares = _convertToShares(assets, false);
     }
 
-    function _convertToShares(uint256 assets) internal view virtual returns (uint256 shares) {
+    function _convertToShares(uint256 assets, bool isRoundUp) internal view virtual returns (uint256 shares) {
         uint256 totalShares = totalSupply();
 
         if (totalShares == 0) {
             shares = assets; // 1:1 value of shares and assets
         } else {
-            shares = (assets * totalShares) / totalAssets();
+            uint256 totalAssetsMem = totalAssets();
+            shares = (assets * totalShares) / totalAssetsMem;
+
+            // Round Up if needed
+            if (isRoundUp && mulmod(assets, totalShares, totalAssetsMem) > 0) {
+                shares += 1;
+            }
         }
     }
 

--- a/contracts/vault/LightBasicVault.sol
+++ b/contracts/vault/LightBasicVault.sol
@@ -66,7 +66,7 @@ contract LightBasicVault is LightAbstractVault, Initializable {
     }
 
     function _previewDeposit(uint256 assets) internal view virtual returns (uint256 shares) {
-        shares = _convertToShares(assets);
+        shares = _convertToShares(assets, false);
     }
 
     function mint(uint256 shares, address receiver)
@@ -90,7 +90,7 @@ contract LightBasicVault is LightAbstractVault, Initializable {
     }
 
     function _previewMint(uint256 shares) internal view virtual returns (uint256 assets) {
-        assets = _convertToAssets(shares);
+        assets = _convertToAssets(shares, true);
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -136,7 +136,7 @@ contract LightBasicVault is LightAbstractVault, Initializable {
     }
 
     function _previewWithdraw(uint256 assets) internal view virtual returns (uint256 shares) {
-        shares = _convertToShares(assets);
+        shares = _convertToShares(assets, true);
     }
 
     function maxWithdraw(address owner) external view override returns (uint256 maxAssets) {
@@ -174,7 +174,7 @@ contract LightBasicVault is LightAbstractVault, Initializable {
     }
 
     function _previewRedeem(uint256 shares) internal view virtual returns (uint256 assets) {
-        assets = _convertToAssets(shares);
+        assets = _convertToAssets(shares, false);
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -220,16 +220,20 @@ contract LightBasicVault is LightAbstractVault, Initializable {
         override
         returns (uint256 assets)
     {
-        assets = _convertToAssets(shares);
+        assets = _convertToAssets(shares, false);
     }
 
-    function _convertToAssets(uint256 shares) internal view virtual returns (uint256 assets) {
+    function _convertToAssets(uint256 shares, bool isRoundUp) internal view virtual returns (uint256 assets) {
         uint256 totalShares = totalSupply();
 
         if (totalShares == 0) {
             assets = shares; // 1:1 value of shares and assets
         } else {
-            assets = (shares * totalAssets()) / totalShares;
+            uint256 totalAssetsMem = totalAssets();
+            assets = (shares * totalAssetsMem) / totalShares;
+            if (isRoundUp && mulmod(shares, totalAssetsMem, totalShares) > 0) {
+                assets += 1;
+            }
         }
     }
 
@@ -240,16 +244,20 @@ contract LightBasicVault is LightAbstractVault, Initializable {
         override
         returns (uint256 shares)
     {
-        shares = _convertToShares(assets);
+        shares = _convertToShares(assets, false);
     }
 
-    function _convertToShares(uint256 assets) internal view virtual returns (uint256 shares) {
+    function _convertToShares(uint256 assets, bool isRoundUp) internal view virtual returns (uint256 shares) {
         uint256 totalShares = totalSupply();
 
         if (totalShares == 0) {
             shares = assets; // 1:1 value of shares and assets
         } else {
-            shares = (assets * totalShares) / totalAssets();
+            uint256 totalAssetsMem = totalAssets();
+            shares = (assets * totalShares) / totalAssetsMem;
+            if (isRoundUp && mulmod(assets, totalShares, totalAssetsMem) > 0) {
+                shares += 1;
+            }
         }
     }
 }

--- a/contracts/vault/allocate/AssetPerShareAbstractVault.sol
+++ b/contracts/vault/allocate/AssetPerShareAbstractVault.sol
@@ -47,7 +47,7 @@ abstract contract AssetPerShareAbstractVault is AbstractVault {
         override
         returns (uint256 shares)
     {
-        shares = _convertToShares(assets);
+        shares = _convertToShares(assets, false);
     }
 
     /**
@@ -55,7 +55,7 @@ abstract contract AssetPerShareAbstractVault is AbstractVault {
      * Use the assets per share value from the last settlement
      */
     function _previewMint(uint256 shares) internal view virtual override returns (uint256 assets) {
-        assets = _convertToAssets(shares);
+        assets = _convertToAssets(shares, true);
     }
 
     /**
@@ -69,7 +69,7 @@ abstract contract AssetPerShareAbstractVault is AbstractVault {
         override
         returns (uint256 shares)
     {
-        shares = _convertToShares(assets);
+        shares = _convertToShares(assets, true);
     }
 
     /**
@@ -83,7 +83,7 @@ abstract contract AssetPerShareAbstractVault is AbstractVault {
         override
         returns (uint256 assets)
     {
-        assets = _convertToAssets(shares);
+        assets = _convertToAssets(shares, false);
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -91,7 +91,7 @@ abstract contract AssetPerShareAbstractVault is AbstractVault {
     //////////////////////////////////////////////////////////////*/
 
     /// @dev uses the stored `assetsPerShare` to convert shares to assets.
-    function _convertToAssets(uint256 shares)
+    function _convertToAssets(uint256 shares, bool isRoundUp)
         internal
         view
         virtual
@@ -99,10 +99,14 @@ abstract contract AssetPerShareAbstractVault is AbstractVault {
         returns (uint256 assets)
     {
         assets = (shares * assetsPerShare) / ASSETS_PER_SHARE_SCALE;
+
+        if (isRoundUp && mulmod(shares, assetsPerShare, ASSETS_PER_SHARE_SCALE) > 0) {
+            assets += 1;
+        }
     }
 
     /// @dev uses the stored `assetsPerShare` to convert assets to shares.
-    function _convertToShares(uint256 assets)
+    function _convertToShares(uint256 assets, bool isRoundUp)
         internal
         view
         virtual
@@ -110,6 +114,10 @@ abstract contract AssetPerShareAbstractVault is AbstractVault {
         returns (uint256 shares)
     {
         shares = (assets * ASSETS_PER_SHARE_SCALE) / assetsPerShare;
+
+        if (isRoundUp && mulmod(assets, ASSETS_PER_SHARE_SCALE, assetsPerShare) > 0) {
+            shares += 1;
+        }
     }
 
     /// @dev Updates assetPerShare of this vault to be expanted by the child contract to charge perf fees every assetPerShare update.

--- a/contracts/vault/allocate/PeriodicAllocationAbstractVault.sol
+++ b/contracts/vault/allocate/PeriodicAllocationAbstractVault.sol
@@ -369,25 +369,25 @@ abstract contract PeriodicAllocationAbstractVault is
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Uses AssetPerShareAbstractVault logic.
-    function _convertToAssets(uint256 shares)
+    function _convertToAssets(uint256 shares, bool isRoundUp)
         internal
         view
         virtual
         override(AssetPerShareAbstractVault, AbstractVault)
         returns (uint256 assets)
     {
-        return AssetPerShareAbstractVault._convertToAssets(shares);
+        return AssetPerShareAbstractVault._convertToAssets(shares, isRoundUp);
     }
 
     /// @dev Uses AssetPerShareAbstractVault logic.
-    function _convertToShares(uint256 assets)
+    function _convertToShares(uint256 assets, bool isRoundUp)
         internal
         view
         virtual
         override(AssetPerShareAbstractVault, AbstractVault)
         returns (uint256 shares)
     {
-        return AssetPerShareAbstractVault._convertToShares(assets);
+        return AssetPerShareAbstractVault._convertToShares(assets, isRoundUp);
     }
 
     /***************************************

--- a/contracts/vault/liquidity/convex/Convex3CrvAbstractVault.sol
+++ b/contracts/vault/liquidity/convex/Convex3CrvAbstractVault.sol
@@ -625,9 +625,9 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
         uint256 _totalMetapoolTokens,
         uint256 _totalShares,
         bool isRoundUp
-    ) internal pure returns (uint256 shares) {
+    ) internal view returns (uint256 shares) {
         if (_totalMetapoolTokens == 0) {
-            shares = _metapoolTokens;
+            shares = (_metapoolTokens * ASSET_SCALE) / metapoolTokenScale;
         } else {
             shares = (_metapoolTokens * _totalShares) / _totalMetapoolTokens;
             if (isRoundUp && mulmod(_metapoolTokens, _totalShares, _totalMetapoolTokens) > 0) {
@@ -641,9 +641,9 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
         uint256 _totalMetapoolTokens,
         uint256 _totalShares,
         bool isRoundUp
-    ) internal pure returns (uint256 metapoolTokens) {
+    ) internal view returns (uint256 metapoolTokens) {
         if (_totalShares == 0) {
-            metapoolTokens = _shares;
+            metapoolTokens = (_shares * metapoolTokenScale) / ASSET_SCALE;
         } else {
             metapoolTokens = (_shares * _totalMetapoolTokens) / _totalShares;
             if (isRoundUp && mulmod(_shares, _totalMetapoolTokens, _totalShares) > 0) {

--- a/contracts/vault/liquidity/convex/Convex3CrvAbstractVault.sol
+++ b/contracts/vault/liquidity/convex/Convex3CrvAbstractVault.sol
@@ -252,7 +252,7 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             shares,
             baseRewardPool.balanceOf(address(this)),
             totalSupply(),
-            true
+            false
         );
         uint256 requiredMetapoolTokens = metapoolTokens + donatedMetapoolTokens;
 
@@ -317,7 +317,7 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
                 shares,
                 baseRewardPool.balanceOf(address(this)),
                 totalSupply(),
-                true
+                false
             );
             (uint256 assetsToDeposit, , , ) = Curve3CrvMetapoolCalculatorLibrary.calcMint(
                 metapool,

--- a/contracts/vault/liquidity/convex/Convex3CrvAbstractVault.sol
+++ b/contracts/vault/liquidity/convex/Convex3CrvAbstractVault.sol
@@ -182,7 +182,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
         uint256 sharesToMint = _getSharesFromMetapoolTokens(
             metapoolTokensReceived,
             totalMetapoolTokensBefore,
-            totalSupply()
+            totalSupply(),
+            false
         );
         // Calculate the proportion of shares to mint to the receiver.
         shares = (sharesToMint * _assets) / assetsToDeposit;
@@ -220,7 +221,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             uint256 sharesToMint = _getSharesFromMetapoolTokens(
                 metapoolTokens,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                false
             );
             // Calculate the callers portion of shares
             shares = (sharesToMint * assets) / assetsToDeposit;
@@ -249,7 +251,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
         uint256 metapoolTokens = _getMetapoolTokensFromShares(
             shares,
             baseRewardPool.balanceOf(address(this)),
-            totalSupply()
+            totalSupply(),
+            true
         );
         uint256 requiredMetapoolTokens = metapoolTokens + donatedMetapoolTokens;
 
@@ -270,6 +273,7 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             1
         );
         assets = (assetsToDeposit * requiredMetapoolTokens) / metapoolTokens;
+
         // Protect against sandwich and flash loan attacks where the balance of the metapool is manipulated.
         uint256 maxAssets = (requiredMetapoolTokens * invariant * VIRTUAL_PRICE_SCALE) /
             (metapoolTotalSupply * baseVirtualPrice);
@@ -312,7 +316,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             uint256 metapoolTokens = _getMetapoolTokensFromShares(
                 shares,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                true
             );
             (uint256 assetsToDeposit, , , ) = Curve3CrvMetapoolCalculatorLibrary.calcMint(
                 metapool,
@@ -356,7 +361,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             shares = _getSharesFromMetapoolTokens(
                 metapoolTokensRequired,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                true
             );
 
             // If caller is not the owner of the shares
@@ -403,7 +409,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             shares = _getSharesFromMetapoolTokens(
                 metapoolTokens,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                true
             );
         }
     }
@@ -453,7 +460,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             uint256 requiredMetapoolTokens = _getMetapoolTokensFromShares(
                 _shares,
                 totalMetapoolTokens,
-                totalSupply()
+                totalSupply(),
+                false
             );
 
             // Calculate fair amount of assets (3Crv) using virtual prices for metapool LP tokens, eg musd3Crv
@@ -494,7 +502,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             uint256 metapoolTokens = _getMetapoolTokensFromShares(
                 shares,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                false
             );
             (assets, , ) = Curve3CrvMetapoolCalculatorLibrary.calcRedeem(
                 metapool,
@@ -510,7 +519,7 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Override `AbstractVault._convertToAssets`.
-    function _convertToAssets(uint256 shares)
+    function _convertToAssets(uint256 shares, bool isRoundUp)
         internal
         view
         virtual
@@ -521,7 +530,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             uint256 metapoolTokens = _getMetapoolTokensFromShares(
                 shares,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                isRoundUp
             );
             assets = Curve3CrvMetapoolCalculatorLibrary.convertToBaseLp(
                 metapool,
@@ -532,7 +542,7 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
     }
 
     /// @dev Override `AbstractVault._convertToShares`.
-    function _convertToShares(uint256 assets)
+    function _convertToShares(uint256 assets, bool isRoundUp)
         internal
         view
         virtual
@@ -548,7 +558,8 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
             shares = _getSharesFromMetapoolTokens(
                 metapoolTokens,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                isRoundUp
             );
         }
     }
@@ -612,24 +623,32 @@ abstract contract Convex3CrvAbstractVault is AbstractSlippage, AbstractVault {
     function _getSharesFromMetapoolTokens(
         uint256 _metapoolTokens,
         uint256 _totalMetapoolTokens,
-        uint256 _totalShares
+        uint256 _totalShares,
+        bool isRoundUp
     ) internal pure returns (uint256 shares) {
         if (_totalMetapoolTokens == 0) {
             shares = _metapoolTokens;
         } else {
             shares = (_metapoolTokens * _totalShares) / _totalMetapoolTokens;
+            if (isRoundUp && mulmod(_metapoolTokens, _totalShares, _totalMetapoolTokens) > 0) {
+                shares += 1;
+            }
         }
     }
 
     function _getMetapoolTokensFromShares(
         uint256 _shares,
         uint256 _totalMetapoolTokens,
-        uint256 _totalShares
+        uint256 _totalShares,
+        bool isRoundUp
     ) internal pure returns (uint256 metapoolTokens) {
         if (_totalShares == 0) {
             metapoolTokens = _shares;
         } else {
             metapoolTokens = (_shares * _totalMetapoolTokens) / _totalShares;
+            if (isRoundUp && mulmod(_shares, _totalMetapoolTokens, _totalShares) > 0) {
+                metapoolTokens += 1;
+            }
         }
     }
 

--- a/contracts/vault/liquidity/convex/Convex3CrvLiquidatorVault.sol
+++ b/contracts/vault/liquidity/convex/Convex3CrvLiquidatorVault.sol
@@ -374,25 +374,25 @@ contract Convex3CrvLiquidatorVault is
     ****************************************/
 
     /// @dev use Convex3CrvAbstractVault implementation.
-    function _convertToAssets(uint256 shares)
+    function _convertToAssets(uint256 shares, bool isRoundUp)
         internal
         view
         virtual
         override(AbstractVault, Convex3CrvAbstractVault)
         returns (uint256 assets)
     {
-        assets = Convex3CrvAbstractVault._convertToAssets(shares);
+        assets = Convex3CrvAbstractVault._convertToAssets(shares, isRoundUp);
     }
 
     /// @dev use Convex3CrvAbstractVault implementation.
-    function _convertToShares(uint256 assets)
+    function _convertToShares(uint256 assets, bool isRoundUp)
         internal
         view
         virtual
         override(AbstractVault, Convex3CrvAbstractVault)
         returns (uint256 shares)
     {
-        shares = Convex3CrvAbstractVault._convertToShares(assets);
+        shares = Convex3CrvAbstractVault._convertToShares(assets, isRoundUp);
     }
 
     /***************************************

--- a/contracts/vault/liquidity/convex/ConvexFraxBpAbstractVault.sol
+++ b/contracts/vault/liquidity/convex/ConvexFraxBpAbstractVault.sol
@@ -253,7 +253,7 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             shares,
             baseRewardPool.balanceOf(address(this)),
             totalSupply(),
-            true
+            false
         );
         uint256 requiredMetapoolTokens = metapoolTokens + donatedMetapoolTokens;
 
@@ -319,7 +319,7 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
                 shares,
                 baseRewardPool.balanceOf(address(this)),
                 totalSupply(),
-                true
+                false
             );
             (uint256 assetsToDeposit, , , ) = CurveFraxBpMetapoolCalculatorLibrary.calcMint(
                 metapool,

--- a/contracts/vault/liquidity/convex/ConvexFraxBpAbstractVault.sol
+++ b/contracts/vault/liquidity/convex/ConvexFraxBpAbstractVault.sol
@@ -183,7 +183,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
         uint256 sharesToMint = _getSharesFromMetapoolTokens(
             metapoolTokensReceived,
             totalMetapoolTokensBefore,
-            totalSupply()
+            totalSupply(),
+            false
         );
         // Calculate the proportion of shares to mint to the receiver.
         shares = (sharesToMint * _assets) / assetsToDeposit;
@@ -221,7 +222,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             uint256 sharesToMint = _getSharesFromMetapoolTokens(
                 metapoolTokens,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                false
             );
             // Calculate the callers portion of shares
             shares = (sharesToMint * assets) / assetsToDeposit;
@@ -250,7 +252,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
         uint256 metapoolTokens = _getMetapoolTokensFromShares(
             shares,
             baseRewardPool.balanceOf(address(this)),
-            totalSupply()
+            totalSupply(),
+            true
         );
         uint256 requiredMetapoolTokens = metapoolTokens + donatedMetapoolTokens;
 
@@ -315,7 +318,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             uint256 metapoolTokens = _getMetapoolTokensFromShares(
                 shares,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                true
             );
             (uint256 assetsToDeposit, , , ) = CurveFraxBpMetapoolCalculatorLibrary.calcMint(
                 metapool,
@@ -364,7 +368,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             shares = _getSharesFromMetapoolTokens(
                 metapoolTokensRequired,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                true
             );
 
             // If caller is not the owner of the shares
@@ -411,7 +416,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             shares = _getSharesFromMetapoolTokens(
                 metapoolTokens,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                true
             );
         }
     }
@@ -461,7 +467,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             uint256 requiredMetapoolTokens = _getMetapoolTokensFromShares(
                 _shares,
                 totalMetapoolTokens,
-                totalSupply()
+                totalSupply(),
+                false
             );
 
             // Calculate fair amount of assets (crvFRAX) using virtual prices for metapool LP tokens, eg BUSDFRAXBP3CRV-f
@@ -502,7 +509,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             uint256 metapoolTokens = _getMetapoolTokensFromShares(
                 shares,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                false
             );
             (assets, , ) = CurveFraxBpMetapoolCalculatorLibrary.calcRedeem(
                 metapool,
@@ -518,7 +526,7 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
     //////////////////////////////////////////////////////////////*/
 
     /// @dev Override `AbstractVault._convertToAssets`.
-    function _convertToAssets(uint256 shares)
+    function _convertToAssets(uint256 shares, bool isRoundUp)
         internal
         view
         virtual
@@ -529,7 +537,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             uint256 metapoolTokens = _getMetapoolTokensFromShares(
                 shares,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                isRoundUp
             );
             assets = CurveFraxBpMetapoolCalculatorLibrary.convertToBaseLp(
                 metapool,
@@ -540,7 +549,7 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
     }
 
     /// @dev Override `AbstractVault._convertToShares`.
-    function _convertToShares(uint256 assets)
+    function _convertToShares(uint256 assets, bool isRoundUp)
         internal
         view
         virtual
@@ -556,7 +565,8 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
             shares = _getSharesFromMetapoolTokens(
                 metapoolTokens,
                 baseRewardPool.balanceOf(address(this)),
-                totalSupply()
+                totalSupply(),
+                isRoundUp
             );
         }
     }
@@ -620,24 +630,32 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
     function _getSharesFromMetapoolTokens(
         uint256 _metapoolTokens,
         uint256 _totalMetapoolTokens,
-        uint256 _totalShares
+        uint256 _totalShares,
+        bool isRoundUp
     ) internal pure returns (uint256 shares) {
         if (_totalMetapoolTokens == 0) {
             shares = _metapoolTokens;
         } else {
             shares = (_metapoolTokens * _totalShares) / _totalMetapoolTokens;
+            if (isRoundUp && mulmod(_metapoolTokens, _totalShares, _totalMetapoolTokens) > 0) {
+                shares += 1;
+            }
         }
     }
 
     function _getMetapoolTokensFromShares(
         uint256 _shares,
         uint256 _totalMetapoolTokens,
-        uint256 _totalShares
+        uint256 _totalShares,
+        bool isRoundUp
     ) internal pure returns (uint256 metapoolTokens) {
         if (_totalShares == 0) {
             metapoolTokens = _shares;
         } else {
             metapoolTokens = (_shares * _totalMetapoolTokens) / _totalShares;
+            if(isRoundUp && mulmod(_shares, _totalMetapoolTokens, _totalShares) > 0) {
+                metapoolTokens += 1;
+            }
         }
     }
 

--- a/contracts/vault/liquidity/convex/ConvexFraxBpAbstractVault.sol
+++ b/contracts/vault/liquidity/convex/ConvexFraxBpAbstractVault.sol
@@ -632,9 +632,9 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
         uint256 _totalMetapoolTokens,
         uint256 _totalShares,
         bool isRoundUp
-    ) internal pure returns (uint256 shares) {
+    ) internal view returns (uint256 shares) {
         if (_totalMetapoolTokens == 0) {
-            shares = _metapoolTokens;
+            shares = (_metapoolTokens * ASSET_SCALE) / metapoolTokenScale;
         } else {
             shares = (_metapoolTokens * _totalShares) / _totalMetapoolTokens;
             if (isRoundUp && mulmod(_metapoolTokens, _totalShares, _totalMetapoolTokens) > 0) {
@@ -648,9 +648,9 @@ abstract contract ConvexFraxBpAbstractVault is AbstractSlippage, AbstractVault {
         uint256 _totalMetapoolTokens,
         uint256 _totalShares,
         bool isRoundUp
-    ) internal pure returns (uint256 metapoolTokens) {
+    ) internal view returns (uint256 metapoolTokens) {
         if (_totalShares == 0) {
-            metapoolTokens = _shares;
+            metapoolTokens = (_shares * metapoolTokenScale) / ASSET_SCALE;
         } else {
             metapoolTokens = (_shares * _totalMetapoolTokens) / _totalShares;
             if(isRoundUp && mulmod(_shares, _totalMetapoolTokens, _totalShares) > 0) {

--- a/contracts/vault/liquidity/convex/ConvexFraxBpLiquidatorVault.sol
+++ b/contracts/vault/liquidity/convex/ConvexFraxBpLiquidatorVault.sol
@@ -316,24 +316,24 @@ contract ConvexFraxBpLiquidatorVault is
         LiquidatorStreamAbstractVault._streamNewShares(newShares, newAssets);
     }
 
-    function _convertToAssets(uint256 shares)
+    function _convertToAssets(uint256 shares, bool isRoundUp)
         internal
         view
         virtual
         override(AbstractVault, ConvexFraxBpAbstractVault)
         returns (uint256 assets)
     {
-        assets = ConvexFraxBpAbstractVault._convertToAssets(shares);
+        assets = ConvexFraxBpAbstractVault._convertToAssets(shares, isRoundUp);
     }
 
-    function _convertToShares(uint256 assets)
+    function _convertToShares(uint256 assets, bool isRoundUp)
         internal
         view
         virtual
         override(AbstractVault, ConvexFraxBpAbstractVault)
         returns (uint256 shares)
     {
-        shares = ConvexFraxBpAbstractVault._convertToShares(assets);
+        shares = ConvexFraxBpAbstractVault._convertToShares(assets, isRoundUp);
     }
 
      /***************************************

--- a/contracts/vault/liquidity/curve/Curve3CrvAbstractMetaVault.sol
+++ b/contracts/vault/liquidity/curve/Curve3CrvAbstractMetaVault.sol
@@ -170,7 +170,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
         shares = _getSharesFromMetaVaultShares(
             metaVaultSharesReceived,
             metaVaultSharesBefore,
-            totalSupply()
+            totalSupply(),
+            false
         );
 
         _mint(_receiver, shares);
@@ -207,7 +208,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
             shares = _getSharesFromMetaVaultShares(
                 metaVaultShares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                false
             );
         }
     }
@@ -238,7 +240,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
         uint256 requiredMetaVaultShares = _getMetaVaultSharesFromShares(
             shares,
             totalMetaVaultShares,
-            totalSupply()
+            totalSupply(),
+            true
         );
 
         // Calculate 3Crv needed to mint the required Meta Vault shares
@@ -289,7 +292,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
             uint256 requiredMetaVaultShares = _getMetaVaultSharesFromShares(
                 shares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                true
             );
 
             // Calculate 3Crv needed to mint the required Meta Vault shares
@@ -343,7 +347,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
             shares = _getSharesFromMetaVaultShares(
                 metaVaultShares,
                 totalMetaVaultSharesBefore,
-                totalSupply()
+                totalSupply(),
+                true
             );
 
             // If caller is not the owner of the shares
@@ -415,7 +420,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
             shares = _getSharesFromMetaVaultShares(
                 metaVaultShares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                true
             );
         }
     }
@@ -493,7 +499,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
             uint256 metaVaultShares = _getMetaVaultSharesFromShares(
                 _shares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                false
             );
 
             // Burn underlying meta vault shares and receive 3Pool LP tokens (3Crv).
@@ -558,7 +565,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
             uint256 metaVaultShares = _getMetaVaultSharesFromShares(
                 shares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                false
             );
 
             // Convert underlying meta vault shares to 3Pool LP tokens (3Crv).
@@ -598,7 +606,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
             metaVaultShares = _getMetaVaultSharesFromShares(
                 shares,
                 totalMetaVaultShares,
-                totalShares
+                totalShares,
+                false
             );
         }
 
@@ -639,7 +648,8 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
             shares = _getSharesFromMetaVaultShares(
                 metaVaultShares,
                 totalMetaVaultShares,
-                totalShares
+                totalShares,
+                false
             );
         }
     }
@@ -718,24 +728,32 @@ abstract contract Curve3CrvAbstractMetaVault is AbstractSlippage, LightAbstractV
     function _getSharesFromMetaVaultShares(
         uint256 _metaVaultShares,
         uint256 _totalMetaVaultShares,
-        uint256 _totalShares
+        uint256 _totalShares,
+        bool isRoundUp
     ) internal pure returns (uint256 shares) {
         if (_totalMetaVaultShares == 0) {
             shares = _metaVaultShares;
         } else {
             shares = (_metaVaultShares * _totalShares) / _totalMetaVaultShares;
+            if (isRoundUp && mulmod(_metaVaultShares, _totalShares, _totalMetaVaultShares) > 0) {
+                shares += 1;
+            }
         }
     }
 
     function _getMetaVaultSharesFromShares(
         uint256 _shares,
         uint256 _totalMetaVaultShares,
-        uint256 _totalShares
+        uint256 _totalShares,
+        bool isRoundUp
     ) internal pure returns (uint256 metaVaultShares) {
         if (_totalShares == 0) {
             metaVaultShares = _shares;
         } else {
             metaVaultShares = (_shares * _totalMetaVaultShares) / _totalShares;
+            if (isRoundUp && mulmod(_shares, _totalMetaVaultShares, _totalShares) > 0) {
+                metaVaultShares += 1;
+            }
         }
     }
 

--- a/contracts/vault/liquidity/curve/CurveFraxBpAbstractMetaVault.sol
+++ b/contracts/vault/liquidity/curve/CurveFraxBpAbstractMetaVault.sol
@@ -168,7 +168,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
         shares = _getSharesFromMetaVaultShares(
             metaVaultSharesReceived,
             metaVaultSharesBefore,
-            totalSupply()
+            totalSupply(),
+            false
         );
 
         _mint(_receiver, shares);
@@ -205,7 +206,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
             shares = _getSharesFromMetaVaultShares(
                 metaVaultShares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                false
             );
         }
     }
@@ -236,7 +238,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
         uint256 requiredMetaVaultShares = _getMetaVaultSharesFromShares(
             shares,
             totalMetaVaultShares,
-            totalSupply()
+            totalSupply(),
+            true
         );
 
         // Calculate crvFrax needed to mint the required Meta Vault shares
@@ -287,7 +290,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
             uint256 requiredMetaVaultShares = _getMetaVaultSharesFromShares(
                 shares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                true
             );
 
             // Calculate crvFrax needed to mint the required Meta Vault shares
@@ -341,7 +345,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
             shares = _getSharesFromMetaVaultShares(
                 metaVaultShares,
                 totalMetaVaultSharesBefore,
-                totalSupply()
+                totalSupply(),
+                true
             );
 
             // If caller is not the owner of the shares
@@ -413,7 +418,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
             shares = _getSharesFromMetaVaultShares(
                 metaVaultShares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                true
             );
         }
     }
@@ -491,7 +497,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
             uint256 metaVaultShares = _getMetaVaultSharesFromShares(
                 _shares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                false
             );
 
             // Burn underlying meta vault shares and receive FraxBp LP tokens (crvFrax).
@@ -556,7 +563,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
             uint256 metaVaultShares = _getMetaVaultSharesFromShares(
                 shares,
                 totalMetaVaultShares,
-                totalSupply()
+                totalSupply(),
+                false
             );
 
             // Convert underlying meta vault shares to FraxBp LP tokens (crvFrax).
@@ -596,7 +604,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
             metaVaultShares = _getMetaVaultSharesFromShares(
                 shares,
                 totalMetaVaultShares,
-                totalShares
+                totalShares,
+                false
             );
         }
 
@@ -637,7 +646,8 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
             shares = _getSharesFromMetaVaultShares(
                 metaVaultShares,
                 totalMetaVaultShares,
-                totalShares
+                totalShares,
+                false
             );
         }
     }
@@ -716,24 +726,32 @@ abstract contract CurveFraxBpAbstractMetaVault is AbstractSlippage, LightAbstrac
     function _getSharesFromMetaVaultShares(
         uint256 _metaVaultShares,
         uint256 _totalMetaVaultShares,
-        uint256 _totalShares
+        uint256 _totalShares,
+        bool isRoundUp
     ) internal pure returns (uint256 shares) {
         if (_totalMetaVaultShares == 0) {
             shares = _metaVaultShares;
         } else {
             shares = (_metaVaultShares * _totalShares) / _totalMetaVaultShares;
+            if (isRoundUp && mulmod(_metaVaultShares, _totalShares, _totalMetaVaultShares) > 0) {
+                shares += 1;
+            }
         }
     }
 
     function _getMetaVaultSharesFromShares(
         uint256 _shares,
         uint256 _totalMetaVaultShares,
-        uint256 _totalShares
+        uint256 _totalShares,
+        bool isRoundUp
     ) internal pure returns (uint256 metaVaultShares) {
         if (_totalShares == 0) {
             metaVaultShares = _shares;
         } else {
             metaVaultShares = (_shares * _totalMetaVaultShares) / _totalShares;
+            if (isRoundUp && mulmod(_shares, _totalMetaVaultShares, _totalShares) > 0) {
+                metaVaultShares += 1;
+            }
         }
     }
 

--- a/contracts/vault/meta/PeriodicAllocationPerfFeeMetaVault.sol
+++ b/contracts/vault/meta/PeriodicAllocationPerfFeeMetaVault.sol
@@ -174,25 +174,25 @@ contract PeriodicAllocationPerfFeeMetaVault is
     //////////////////////////////////////////////////////////////*/
 
     /// @dev use PeriodicAllocationAbstractVault implementation.
-    function _convertToAssets(uint256 shares)
+    function _convertToAssets(uint256 shares, bool isRoundUp)
         internal
         view
         virtual
         override(AbstractVault, PeriodicAllocationAbstractVault)
         returns (uint256 assets)
     {
-        return PeriodicAllocationAbstractVault._convertToAssets(shares);
+        return PeriodicAllocationAbstractVault._convertToAssets(shares, isRoundUp);
     }
 
     /// @dev use PeriodicAllocationAbstractVault implementation.
-    function _convertToShares(uint256 assets)
+    function _convertToShares(uint256 assets, bool isRoundUp)
         internal
         view
         virtual
         override(AbstractVault, PeriodicAllocationAbstractVault)
         returns (uint256 shares)
     {
-        return PeriodicAllocationAbstractVault._convertToShares(assets);
+        return PeriodicAllocationAbstractVault._convertToShares(assets, isRoundUp);
     }
 
     /***************************************

--- a/test-fork/vault/ConvexFraxBpLiquidatorVault.spec.ts
+++ b/test-fork/vault/ConvexFraxBpLiquidatorVault.spec.ts
@@ -255,6 +255,26 @@ describe("Convex FraxBp Liquidator Vault", async () => {
             behaveLikeConvexFraxBpVault(() => ctx)
         })
     })
+    describe("withdraw should round up", async () => {
+        before(async () => {
+            await setup(normalBlock)
+            await deployVault()
+
+            await crvFraxToken.connect(staker1.signer).approve(busdFraxConvexVault.address, SAFE_INFINITY)
+        })
+        it("withdrawing assets should round up", async () => {
+            // vault asset/share ratio is 11:10 after the following 2 transactions
+            await busdFraxConvexVault.connect(staker1.signer)["deposit(uint256,address)"](10, staker1.address)
+            await crvFraxToken.connect(staker1.signer).transfer(busdFraxConvexVault.address, 1)
+
+            const userSharesBefore = await busdFraxConvexVault.balanceOf(staker1.address)
+            // asset/share ratio is 11:10. Thus, when withdrawing 3 assets, it would result in 2.73 shares burned from user
+            // According to erc4626 it should round up, thus burning 3 shares
+            await busdFraxConvexVault.connect(staker1.signer).withdraw(3, staker1.address, staker1.address)
+            const userSharesAfter = await busdFraxConvexVault.balanceOf(staker1.address)
+            expect(userSharesAfter).to.be.eq(userSharesBefore.sub(3))
+        })
+    })
     describe("reward liquidations", () => {
         before(async () => {
             await setup(normalBlock)

--- a/test-fork/vault/Curve3CrvBasicMetaVault.spec.ts
+++ b/test-fork/vault/Curve3CrvBasicMetaVault.spec.ts
@@ -182,70 +182,145 @@ describe("Curve 3Crv Basic Vault", async () => {
     })
 
     describe("DAI 3Pooler Vault", () => {
-        before(() => {
-            // Anonymous functions cannot be used as fixtures so can't use arrow function
-            ctx.fixture = async function fixture() {
-                await commonSetup(normalBlock)
+        describe("should behave like Curve3Crv Vault", async () => {
+            before(() => {
+                // Anonymous functions cannot be used as fixtures so can't use arrow function
+                ctx.fixture = async function fixture() {
+                    await commonSetup(normalBlock)
 
-                // Reset ctx values from commonSetup
-                ctx.threePool = threePool
-                ctx.metaVault = metaVault
-                ctx.governor = governor
+                    // Reset ctx values from commonSetup
+                    ctx.threePool = threePool
+                    ctx.metaVault = metaVault
+                    ctx.governor = governor
 
-                // Asset specific values
-                ctx.owner = await impersonateAccount(daiUserAddress)
-                ctx.asset = IERC20__factory.connect(DAI.address, ctx.owner.signer)
-                ctx.amounts = testAmounts(100000, DAI.decimals)
+                    // Asset specific values
+                    ctx.owner = await impersonateAccount(daiUserAddress)
+                    ctx.asset = IERC20__factory.connect(DAI.address, ctx.owner.signer)
+                    ctx.amounts = testAmounts(100000, DAI.decimals)
 
-                // Deploy new Curve3CrvBasicMetaVault
-                ctx.vault = await deployVault(ctx.asset, ctx.owner)
-            }
+                    // Deploy new Curve3CrvBasicMetaVault
+                    ctx.vault = await deployVault(ctx.asset, ctx.owner)
+                }
+            })
+            behaveLikeCurve3CrvVault(() => ctx)
         })
-        behaveLikeCurve3CrvVault(() => ctx)
+        describe("withdraw should round up", async () => {
+            let vault: Curve3CrvBasicMetaVault
+            let owner: Account
+            let asset: IERC20
+            before(async () => {
+                await commonSetup(normalBlock)
+                owner = await impersonateAccount(daiUserAddress)
+                asset = IERC20__factory.connect(DAI.address, owner.signer)
+                vault = await deployVault(asset, owner)
+            })
+            it("withdrawing assets should round up", async () => {
+                // vault asset/share ratio is 11:10 after the following 2 transactions
+                await vault.connect(owner.signer)["deposit(uint256,address)"](10, owner.address)
+                await asset.connect(owner.signer).transfer(vault.address, 1)
+
+                const userSharesBefore = await vault.balanceOf(owner.address)
+                // asset/share ratio is 11:10. Thus, when withdrawing 3 assets, it would result in 2.73 shares burned from user
+                // According to erc4626 it should round up, thus burning 3 shares
+                await vault.connect(owner.signer).withdraw(3, owner.address, owner.address)
+                const userSharesAfter = await vault.balanceOf(owner.address)
+                expect(userSharesAfter).to.be.eq(userSharesBefore.sub(3))
+            })
+        })
     })
     describe("USDC 3Pooler Vault", () => {
-        before(() => {
-            // Anonymous functions cannot be used as fixtures so can't use arrow function
-            ctx.fixture = async function fixture() {
-                await commonSetup(normalBlock)
+        describe("should behave like Curve3Crv Vault", async () => {
+            before(() => {
+                // Anonymous functions cannot be used as fixtures so can't use arrow function
+                ctx.fixture = async function fixture() {
+                    await commonSetup(normalBlock)
 
-                // Reset ctx values from commonSetup
-                ctx.threePool = threePool
-                ctx.metaVault = metaVault
-                ctx.governor = governor
+                    // Reset ctx values from commonSetup
+                    ctx.threePool = threePool
+                    ctx.metaVault = metaVault
+                    ctx.governor = governor
 
-                // Asset specific values
-                ctx.owner = await impersonateAccount(usdcUserAddress)
-                ctx.asset = IERC20__factory.connect(USDC.address, ctx.owner.signer)
-                ctx.amounts = testAmounts(100000, USDC.decimals)
+                    // Asset specific values
+                    ctx.owner = await impersonateAccount(usdcUserAddress)
+                    ctx.asset = IERC20__factory.connect(USDC.address, ctx.owner.signer)
+                    ctx.amounts = testAmounts(100000, USDC.decimals)
 
-                // Deploy new Curve3CrvBasicMetaVault
-                ctx.vault = await deployVault(ctx.asset, ctx.owner)
-            }
+                    // Deploy new Curve3CrvBasicMetaVault
+                    ctx.vault = await deployVault(ctx.asset, ctx.owner)
+                }
+            })
+            behaveLikeCurve3CrvVault(() => ctx)
         })
-        behaveLikeCurve3CrvVault(() => ctx)
+        describe("withdraw should round up", async () => {
+            let vault: Curve3CrvBasicMetaVault
+            let owner: Account
+            let asset: IERC20
+            before(async () => {
+                await commonSetup(normalBlock)
+                owner = await impersonateAccount(usdcUserAddress)
+                asset = IERC20__factory.connect(USDC.address, owner.signer)
+                vault = await deployVault(asset, owner)
+            })
+            it("withdrawing assets should round up", async () => {
+                // vault asset/share ratio is 11:10 after the following 2 transactions
+                await vault.connect(owner.signer)["deposit(uint256,address)"](10, owner.address)
+                await asset.connect(owner.signer).transfer(vault.address, 1)
+
+                const userSharesBefore = await vault.balanceOf(owner.address)
+                // asset/share ratio is 11:10. Thus, when withdrawing 3 assets, it would result in 2.73 shares burned from user
+                // According to erc4626 it should round up, thus burning 3 shares
+                await vault.connect(owner.signer).withdraw(3, owner.address, owner.address)
+                const userSharesAfter = await vault.balanceOf(owner.address)
+                expect(userSharesAfter).to.be.eq(userSharesBefore.sub(3))
+            })
+        })
     })
     describe("USDT 3Pooler Vault", () => {
-        before(() => {
-            // Anonymous functions cannot be used as fixtures so can't use arrow function
-            ctx.fixture = async function fixture() {
-                await commonSetup(normalBlock)
+        describe("should behave like Curve3Crv Vault", async () => {
+            before(() => {
+                // Anonymous functions cannot be used as fixtures so can't use arrow function
+                ctx.fixture = async function fixture() {
+                    await commonSetup(normalBlock)
 
-                // Reset ctx values from commonSetup
-                ctx.threePool = threePool
-                ctx.metaVault = metaVault
-                ctx.governor = governor
+                    // Reset ctx values from commonSetup
+                    ctx.threePool = threePool
+                    ctx.metaVault = metaVault
+                    ctx.governor = governor
 
-                // Asset specific values
-                ctx.owner = await impersonateAccount(usdtUserAddress)
-                ctx.asset = IERC20__factory.connect(USDT.address, ctx.owner.signer)
-                ctx.amounts = testAmounts(100000, USDT.decimals)
+                    // Asset specific values
+                    ctx.owner = await impersonateAccount(usdtUserAddress)
+                    ctx.asset = IERC20__factory.connect(USDT.address, ctx.owner.signer)
+                    ctx.amounts = testAmounts(100000, USDT.decimals)
 
-                // Deploy new Curve3CrvBasicMetaVault
-                ctx.vault = await deployVault(ctx.asset, ctx.owner)
-            }
+                    // Deploy new Curve3CrvBasicMetaVault
+                    ctx.vault = await deployVault(ctx.asset, ctx.owner)
+                }
+            })
+            behaveLikeCurve3CrvVault(() => ctx)
         })
-        behaveLikeCurve3CrvVault(() => ctx)
+        describe("withdraw should round up", async () => {
+            let vault: Curve3CrvBasicMetaVault
+            let owner: Account
+            let asset: IERC20
+            before(async () => {
+                await commonSetup(normalBlock)
+                owner = await impersonateAccount(usdtUserAddress)
+                asset = IERC20__factory.connect(USDT.address, owner.signer)
+                vault = await deployVault(asset, owner)
+            })
+            it("withdrawing assets should round up", async () => {
+                // vault asset/share ratio is 11:10 after the following 2 transactions
+                await vault.connect(owner.signer)["deposit(uint256,address)"](10, owner.address)
+                await asset.connect(owner.signer).transfer(vault.address, 1)
+
+                const userSharesBefore = await vault.balanceOf(owner.address)
+                // asset/share ratio is 11:10. Thus, when withdrawing 3 assets, it would result in 2.73 shares burned from user
+                // According to erc4626 it should round up, thus burning 3 shares
+                await vault.connect(owner.signer).withdraw(3, owner.address, owner.address)
+                const userSharesAfter = await vault.balanceOf(owner.address)
+                expect(userSharesAfter).to.be.eq(userSharesBefore.sub(3))
+            })
+        })
     })
     describe("validations", () => {
         before(async () => {

--- a/test-fork/vault/saveFraxPlus.spec.ts
+++ b/test-fork/vault/saveFraxPlus.spec.ts
@@ -1263,6 +1263,7 @@ describe("SaveFrax+ Basic and Meta Vaults", async () => {
         })
         describe("mint and withdraw should round up", () => {
             it("minting shares should round up", async () => {
+                await loadOrExecFixture(setup)
                 let owner = crvFraxWhale1
                 let vault = periodicAllocationPerfFeeMetaVault
                 // vault asset/share ratio is 11:10 after the following 2 transactions

--- a/test-fork/vault/saveFraxPlus.spec.ts
+++ b/test-fork/vault/saveFraxPlus.spec.ts
@@ -1261,6 +1261,43 @@ describe("SaveFrax+ Basic and Meta Vaults", async () => {
                 })
             })
         })
+        describe("mint and withdraw should round up", () => {
+            it("minting shares should round up", async () => {
+                let owner = crvFraxWhale1
+                let vault = periodicAllocationPerfFeeMetaVault
+                // vault asset/share ratio is 11:10 after the following 2 transactions
+                await vault.connect(owner.signer).deposit(10, owner.address)
+                await crvFraxToken.transfer(vault.address, 1)
+
+                await vault.connect(sa.vaultManager.signer).updateAssetPerShare()
+            
+                const userAssetsBefore = await crvFraxToken.balanceOf(owner.address)
+                console.log("userAssetsBefore: ", userAssetsBefore.toString())
+                // asset/share ratio is 11:10. Thus, when minting 3 shares, it would result in 3.33 assets transferred from user
+                // According to erc4626 it should round up, thus it should transfer 4 assets
+                await vault.connect(owner.signer).mint(3, owner.address)
+                const userAssetsAfter = await crvFraxToken.balanceOf(owner.address)
+                console.log("userAssetsAfter: ", userAssetsAfter.toString())
+                expect(userAssetsAfter).to.be.eq(userAssetsBefore.sub(4))
+            })
+            it("withdrawing assets should round up", async () => {
+                await loadOrExecFixture(setup)
+                let owner = crvFraxWhale1
+                let vault = periodicAllocationPerfFeeMetaVault
+                // vault asset/share ratio is 11:10 after the following 2 transactions
+                await vault.connect(owner.signer)["deposit(uint256,address)"](10, owner.address)
+                await crvFraxToken.connect(owner.signer).transfer(vault.address, 1)
+
+                await vault.connect(sa.vaultManager.signer).updateAssetPerShare()
+
+                const userSharesBefore = await vault.balanceOf(owner.address)
+                // asset/share ratio is 11:10. Thus, when withdrawing 3 assets, it would result in 2.73 shares burned from user
+                // According to erc4626 it should round up, thus burning 3 shares
+                await vault.connect(owner.signer).withdraw(3, owner.address, owner.address)
+                const userSharesAfter = await vault.balanceOf(owner.address)
+                expect(userSharesAfter).to.be.eq(userSharesBefore.sub(3))
+            })
+        })
     })
     context("CurveFraxBpBasicMetaVault", async () => {
         let vaultsDataBefore
@@ -1304,8 +1341,8 @@ describe("SaveFrax+ Basic and Meta Vaults", async () => {
             })
             it("mint shares", async () => {
                 // When mint via 4626MetaVault
-                await assertVaultMint(usdcWhale, usdcToken, usdcMetaVault, dataEmitter, simpleToExactAmount(70000, crvFRAX.decimals))
-                await assertVaultMint(fraxWhale, fraxToken, fraxMetaVault, dataEmitter, simpleToExactAmount(70000, crvFRAX.decimals))
+                await assertVaultMint(usdcWhale, usdcToken, usdcMetaVault, dataEmitter, simpleToExactAmount(70000, USDC.decimals))
+                await assertVaultMint(fraxWhale, fraxToken, fraxMetaVault, dataEmitter, simpleToExactAmount(70000, FRAX.decimals))
 
                 const vaultsDataAfter = await snapshotVaults(
                     convexFraxBpLiquidatorVaults,
@@ -1355,8 +1392,8 @@ describe("SaveFrax+ Basic and Meta Vaults", async () => {
                 // no change on underlying vaults
             })
             it("partial redeem", async () => {
-                await assertVaultRedeem(usdcWhale, usdcToken, usdcMetaVault, dataEmitter, simpleToExactAmount(7000, crvFRAX.decimals))
-                await assertVaultRedeem(fraxWhale, fraxToken, fraxMetaVault, dataEmitter, simpleToExactAmount(7000, crvFRAX.decimals))
+                await assertVaultRedeem(usdcWhale, usdcToken, usdcMetaVault, dataEmitter, simpleToExactAmount(7000, USDC.decimals))
+                await assertVaultRedeem(fraxWhale, fraxToken, fraxMetaVault, dataEmitter, simpleToExactAmount(7000, FRAX.decimals))
 
                 const vaultsDataAfter = await snapshotVaults(
                     convexFraxBpLiquidatorVaults,
@@ -1404,8 +1441,8 @@ describe("SaveFrax+ Basic and Meta Vaults", async () => {
                     await assertVaultDeposit(fraxWhale, fraxToken, fraxMetaVault, simpleToExactAmount(50000, FRAX.decimals))
                 })
                 it("mint shares", async () => {
-                    await assertVaultMint(usdcWhale, usdcToken, usdcMetaVault, dataEmitter, simpleToExactAmount(70000, crvFRAX.decimals))
-                    await assertVaultMint(fraxWhale, fraxToken, fraxMetaVault, dataEmitter, simpleToExactAmount(70000, crvFRAX.decimals))
+                    await assertVaultMint(usdcWhale, usdcToken, usdcMetaVault, dataEmitter, simpleToExactAmount(70000, USDC.decimals))
+                    await assertVaultMint(fraxWhale, fraxToken, fraxMetaVault, dataEmitter, simpleToExactAmount(70000, FRAX.decimals))
                 })
                 it("settles to underlying vaults", async () => {
                     const totalAssets = await periodicAllocationPerfFeeMetaVault.totalAssets()
@@ -1432,8 +1469,8 @@ describe("SaveFrax+ Basic and Meta Vaults", async () => {
                     await assertVaultWithdraw(fraxWhale, fraxToken, fraxMetaVault, simpleToExactAmount(60000, FRAX.decimals))
                 })
                 it("partial redeem", async () => {
-                    await assertVaultRedeem(usdcWhale, usdcToken, usdcMetaVault, dataEmitter, simpleToExactAmount(7000, crvFRAX.decimals))
-                    await assertVaultRedeem(fraxWhale, fraxToken, fraxMetaVault, dataEmitter, simpleToExactAmount(7000, crvFRAX.decimals))
+                    await assertVaultRedeem(usdcWhale, usdcToken, usdcMetaVault, dataEmitter, simpleToExactAmount(7000, USDC.decimals))
+                    await assertVaultRedeem(fraxWhale, fraxToken, fraxMetaVault, dataEmitter, simpleToExactAmount(7000, FRAX.decimals))
                 })
                 it("total redeem", async () => {
                     await assertVaultRedeem(usdcWhale, usdcToken, usdcMetaVault, dataEmitter)

--- a/test-fork/vault/savePlus.spec.ts
+++ b/test-fork/vault/savePlus.spec.ts
@@ -756,7 +756,7 @@ describe("Save+ Basic and Meta Vaults", async () => {
     before("reset block number", async () => {
         await loadOrExecFixture(setup)
     })
-    xcontext("deployment check", async () => {
+    context("deployment check", async () => {
         describe("proxy instant admin", async () => {
             it("owner is the multisig governor", async () => {
                 expect(await proxyAdmin.owner(), "owner must be governor").to.be.eq(governorAddress)
@@ -831,7 +831,7 @@ describe("Save+ Basic and Meta Vaults", async () => {
             })
         })
     })
-    xcontext("behaviors", async () => {
+    context("behaviors", async () => {
         context("should behave like AbstractVault", async () => {
             describe("periodicAllocationPerfFeeMetaVault", async () => {
                 const ctx: Partial<BaseVaultBehaviourContext> = {}
@@ -1040,7 +1040,7 @@ describe("Save+ Basic and Meta Vaults", async () => {
                 threeCrvWhale1,
             )
         })
-        xdescribe("basic flow", () => {
+        describe("basic flow", () => {
             it("deposit 3Crv", async () => {
                 await assertVaultDeposit(
                     threeCrvWhale1,
@@ -1089,7 +1089,7 @@ describe("Save+ Basic and Meta Vaults", async () => {
                 expect(vaultsDataAfter.periodicAllocationPerfFeeMetaVault.vault.totalAssets, "meta vault total assets").to.be.eq(0)
             })
         })
-        xdescribe("full flow with settlement", () => {
+        describe("full flow with settlement", () => {
             describe("before settlement", () => {
                 it("deposit 3Crv", async () => {
                     await assertVaultDeposit(
@@ -1355,7 +1355,7 @@ describe("Save+ Basic and Meta Vaults", async () => {
             })
         })
     })
-    xcontext("Curve3CrvBasicMetaVault", async () => {
+    context("Curve3CrvBasicMetaVault", async () => {
         let vaultsDataBefore
 
         before("reset block number", async () => {
@@ -1587,7 +1587,7 @@ describe("Save+ Basic and Meta Vaults", async () => {
             })
         })
     })
-    xcontext("Convex3CrvLiquidatorVault", async () => {
+    context("Convex3CrvLiquidatorVault", async () => {
         before("reset block number", async () => {
             await loadOrExecFixture(setup)
         })

--- a/test-fork/vault/shared/Convex3Crv.behaviour.ts
+++ b/test-fork/vault/shared/Convex3Crv.behaviour.ts
@@ -150,8 +150,10 @@ export const behaveLikeConvex3CrvVault = (ctx: () => Convex3CrvContext): void =>
         const { baseRewardsPool, vault } = ctx()
         const totalTokens = await baseRewardsPool.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
+        const assetScale = await vault.ASSET_SCALE()
+        const metapoolTokenScale = await vault.metapoolTokenScale()
         if (totalTokens.eq(0)) {
-            return tokens
+            return tokens.mul(assetScale).div(metapoolTokenScale)
         } else {
             return isRoundUp ? roundUp(tokens.mul(totalShares), totalTokens) : tokens.mul(totalShares).div(totalTokens)
         }
@@ -160,8 +162,10 @@ export const behaveLikeConvex3CrvVault = (ctx: () => Convex3CrvContext): void =>
         const { baseRewardsPool, vault } = ctx()
         const totalTokens = await baseRewardsPool.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
+        const assetScale = await vault.ASSET_SCALE()
+        const metapoolTokenScale = await vault.metapoolTokenScale()
         if (totalShares.eq(0)) {
-            return shares
+            return shares.mul(metapoolTokenScale).div(assetScale)
         } else {
             return isRoundUp ? roundUp(shares.mul(totalTokens), totalShares) : shares.mul(totalTokens).div(totalShares)
         }

--- a/test-fork/vault/shared/ConvexFraxBp.behaviour.ts
+++ b/test-fork/vault/shared/ConvexFraxBp.behaviour.ts
@@ -148,8 +148,10 @@ export const behaveLikeConvexFraxBpVault = (ctx: () => ConvexFraxBpContext): voi
         const { baseRewardsPool, vault } = ctx()
         const totalTokens = await baseRewardsPool.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
+        const assetScale = await vault.ASSET_SCALE()
+        const metapoolTokenScale = await vault.metapoolTokenScale()
         if (totalTokens.eq(0)) {
-            return tokens
+            return tokens.mul(assetScale).div(metapoolTokenScale)
         } else {
             return isRoundUp ? roundUp(tokens.mul(totalShares), totalTokens) : tokens.mul(totalShares).div(totalTokens)
         }
@@ -158,8 +160,10 @@ export const behaveLikeConvexFraxBpVault = (ctx: () => ConvexFraxBpContext): voi
         const { baseRewardsPool, vault } = ctx()
         const totalTokens = await baseRewardsPool.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
+        const assetScale = await vault.ASSET_SCALE()
+        const metapoolTokenScale = await vault.metapoolTokenScale()
         if (totalShares.eq(0)) {
-            return shares
+            return shares.mul(metapoolTokenScale).div(assetScale)
         } else {
             return isRoundUp ? roundUp(shares.mul(totalTokens), totalShares) : shares.mul(totalTokens).div(totalShares)
         }

--- a/test-fork/vault/shared/ConvexFraxBp.behaviour.ts
+++ b/test-fork/vault/shared/ConvexFraxBp.behaviour.ts
@@ -2,7 +2,7 @@ import { usdFormatter } from "@tasks/utils"
 import { logger } from "@tasks/utils/logger"
 import { crvFRAX } from "@tasks/utils/tokens"
 import { ONE_DAY, SAFE_INFINITY, ZERO, ZERO_ADDRESS } from "@utils/constants"
-import { basisPointDiff, BN, simpleToExactAmount } from "@utils/math"
+import { basisPointDiff, BN, simpleToExactAmount, roundUp } from "@utils/math"
 import { increaseTime } from "@utils/time"
 import { expect } from "chai"
 import { Wallet } from "ethers"
@@ -144,24 +144,24 @@ export const behaveLikeConvexFraxBpVault = (ctx: () => ConvexFraxBpContext): voi
         const metapoolVP = await metapool.get_virtual_price()
         return fraxBasePoolVP.mul(assets).div(metapoolVP)
     }
-    const getSharesFromTokens = async (tokens: BN): Promise<BN> => {
+    const getSharesFromTokens = async (tokens: BN, isRoundUp: boolean): Promise<BN> => {
         const { baseRewardsPool, vault } = ctx()
         const totalTokens = await baseRewardsPool.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
         if (totalTokens.eq(0)) {
             return tokens
         } else {
-            return tokens.mul(totalShares).div(totalTokens)
+            return isRoundUp ? roundUp(tokens.mul(totalShares), totalTokens) : tokens.mul(totalShares).div(totalTokens)
         }
     }
-    const getTokensFromShares = async (shares: BN): Promise<BN> => {
+    const getTokensFromShares = async (shares: BN, isRoundUp: boolean): Promise<BN> => {
         const { baseRewardsPool, vault } = ctx()
         const totalTokens = await baseRewardsPool.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
         if (totalShares.eq(0)) {
             return shares
         } else {
-            return shares.mul(totalTokens).div(totalShares)
+            return isRoundUp ? roundUp(shares.mul(totalTokens), totalShares) : shares.mul(totalTokens).div(totalShares)
         }
     }
     const sendStaticTxs = async (
@@ -233,7 +233,7 @@ export const behaveLikeConvexFraxBpVault = (ctx: () => ConvexFraxBpContext): voi
         it("convertToAssets()", async () => {
             const { owner, vault } = ctx()
 
-            const expectedAssets = await getAssetsFromTokens(await getTokensFromShares(standardSharesAmount))
+            const expectedAssets = await getAssetsFromTokens(await getTokensFromShares(standardSharesAmount, false))
             expect(await vault.convertToAssets(standardSharesAmount), "convertToAssets").gte(expectedAssets)
 
             await owner.signer.sendTransaction(await vault.populateTransaction.convertToAssets(standardSharesAmount))
@@ -241,7 +241,7 @@ export const behaveLikeConvexFraxBpVault = (ctx: () => ConvexFraxBpContext): voi
         it("convertToShares()", async () => {
             const { owner, vault } = ctx()
 
-            const expectedShares = await getSharesFromTokens(await getTokensFromAssets(standardAssetsAmount))
+            const expectedShares = await getSharesFromTokens(await getTokensFromAssets(standardAssetsAmount), false)
             expect(await vault.convertToShares(standardAssetsAmount), "convertToShares").lte(expectedShares)
 
             await owner.signer.sendTransaction(await vault.populateTransaction.convertToShares(standardAssetsAmount))

--- a/test-fork/vault/shared/Curve3Crv.behaviour.ts
+++ b/test-fork/vault/shared/Curve3Crv.behaviour.ts
@@ -45,8 +45,10 @@ export const behaveLikeCurve3CrvVault = (ctx: () => Curve3CrvContext): void => {
         let metaVaultShares: BN
         const totalMetaVaultShares = await metaVault.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
+        const metaVaultScale = await vault.metaVaultScale()
+        const assetScale = await vault.assetScale()
         if (totalShares.eq(0)) {
-            metaVaultShares = shares
+            metaVaultShares = shares.mul(metaVaultScale).div(assetScale)
         } else {
             metaVaultShares = shares.mul(totalMetaVaultShares).div(totalShares)
         }
@@ -64,8 +66,10 @@ export const behaveLikeCurve3CrvVault = (ctx: () => Curve3CrvContext): void => {
         let shares: BN
         const totalMetaVaultShares = await metaVault.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
+        const metaVaultScale = await vault.metaVaultScale()
+        const assetScale = await vault.assetScale()
         if (totalMetaVaultShares.eq(0)) {
-            shares = metaVaultShares
+            shares = metaVaultShares.mul(assetScale).div(metaVaultScale)
         } else {
             shares = metaVaultShares.mul(totalShares).div(totalMetaVaultShares)
         }

--- a/test-fork/vault/shared/CurveFraxBp.behaviour.ts
+++ b/test-fork/vault/shared/CurveFraxBp.behaviour.ts
@@ -43,8 +43,10 @@ export const behaveLikeCurveFraxBpVault = (ctx: () => CurveFraxBpContext): void 
         let metaVaultShares: BN
         const totalMetaVaultShares = await metaVault.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
+        const metaVaultScale = await vault.metaVaultScale()
+        const assetScale = await vault.assetScale()
         if (totalShares.eq(0)) {
-            metaVaultShares = shares
+            metaVaultShares = shares.mul(metaVaultScale).div(assetScale)
         } else {
             metaVaultShares = shares.mul(totalMetaVaultShares).div(totalShares)
         }
@@ -62,8 +64,10 @@ export const behaveLikeCurveFraxBpVault = (ctx: () => CurveFraxBpContext): void 
         let shares: BN
         const totalMetaVaultShares = await metaVault.balanceOf(vault.address)
         const totalShares = await vault.totalSupply()
+        const metaVaultScale = await vault.metaVaultScale()
+        const assetScale = await vault.assetScale()
         if (totalMetaVaultShares.eq(0)) {
-            shares = metaVaultShares
+            shares = metaVaultShares.mul(assetScale).div(metaVaultScale)
         } else {
             shares = metaVaultShares.mul(totalShares).div(totalMetaVaultShares)
         }

--- a/test-utils/math.ts
+++ b/test-utils/math.ts
@@ -110,3 +110,5 @@ export const sqrt = (value: BN | number): BN => {
 export const sum = (a: BN, b: BN): BN => a.add(b)
 
 export const basisPointDiff = (a: BN, b: BN): BN => ((a.sub(b).mul(10000))).div(a)
+
+export const roundUp = (a: BN, b: BN): BN => (a.mod(b).gt(0) ? a.div(b).add(1) : a.div(b))

--- a/test/shared/BaseVault.behaviour.ts
+++ b/test/shared/BaseVault.behaviour.ts
@@ -587,14 +587,13 @@ export function shouldBehaveLikeBaseVault(ctx: () => BaseVaultBehaviourContext):
     })
 }
 
-export const testAmounts = (amount: number, assetDecimals = 18, vaultDecimals = 18): Amounts => {
-    vaultDecimals = assetDecimals
+export const testAmounts = (amount: number, assetDecimals = 18): Amounts => {
     return {
         initialDeposit: simpleToExactAmount(amount, assetDecimals).mul(6),
         deposit: simpleToExactAmount(amount, assetDecimals),
-        mint: simpleToExactAmount(amount, vaultDecimals),
+        mint: simpleToExactAmount(amount, assetDecimals),
         withdraw: simpleToExactAmount(amount, assetDecimals),
-        redeem: simpleToExactAmount(amount, vaultDecimals),
+        redeem: simpleToExactAmount(amount, assetDecimals),
     }
 }
 

--- a/test/shared/BaseVault.behaviour.ts
+++ b/test/shared/BaseVault.behaviour.ts
@@ -588,6 +588,7 @@ export function shouldBehaveLikeBaseVault(ctx: () => BaseVaultBehaviourContext):
 }
 
 export const testAmounts = (amount: number, assetDecimals = 18, vaultDecimals = 18): Amounts => {
+    vaultDecimals = assetDecimals
     return {
         initialDeposit: simpleToExactAmount(amount, assetDecimals).mul(6),
         deposit: simpleToExactAmount(amount, assetDecimals),


### PR DESCRIPTION
ERC-4626 expects the result returned from the following functions of Vaults to be rounded up:

```solidity
function _previewWithdraw(uint256 assets) 
	internal view virtual 
	returns (uint256 shares)

function _previewMint(uint256 shares) 
	internal view virtual 
	returns (uint256 assets)
```

Due to how Solidity division works, the current implementation of those two functions currently rounds the result down - thus not conforming to ERC-4626 standard.

Included in this PR:
- Round up for `mint`, `withdraw` and corresponding tests for all vaults. Note that Curve and Convex Liquidity vaults do not need round up for mint as we are anyways doing it through `MINT_ADJUST` in the calc library.
- Fix for the bug where the first deposit to CurveMetaVault (or ConvexLiquidatorVaults) can lead to very large amounts of shares minted to user because of decimals mismatch between `shares` and `_metaVaultShares`
```solidity
function _getSharesFromMetaVaultShares(
        uint256 _metaVaultShares,
        uint256 _totalMetaVaultShares,
        uint256 _totalShares
    ) internal pure returns (uint256 shares) {
        if (_totalMetaVaultShares == 0) {
            shares = _metaVaultShares;
        } else {
            shares = (_metaVaultShares * _totalShares) / _totalMetaVaultShares;
        }
    }
```
- Several decimals value fixes in the `savePlus` and `saveFraxPlus` fork-tests